### PR TITLE
指摘内容を修正

### DIFF
--- a/html_css_output_beginner/index.html
+++ b/html_css_output_beginner/index.html
@@ -11,8 +11,8 @@
 <body>
     <div class="container">
         <div class="header">
+                <h1>レジュメ</h1>
             <ul>
-                <li><span>レジュメ</span></li>
                 <li>自己紹介</li>
                 <li>ﾌﾟﾛﾌｨｰﾙ画像</li>
             </ul>
@@ -31,7 +31,7 @@
                         鈴木太郎です。鈴木太郎です。鈴木太郎です。鈴木太郎です。鈴木太郎です。<br>
                         鈴木太郎です。鈴木太郎です。鈴木太郎です。鈴木太郎です。鈴木太郎です。</p>
                 </div>
-                <img class="self_image" src="/still/self_introduction.png" alt="自己紹介画像">
+                <img class="self_image" src="./still/self_introduction.png" alt="自己紹介画像">
             </div>
             <div class="profile_wrapper">
                 <div>
@@ -41,23 +41,23 @@
                     <div class="profile">
                         <p class="profile_name">タイトルタイトル</p>
                         <p class="profile_text">テキストテキストテキスト</p>
-                        <img class="profile_image" src="/still/profile.png" alt="プロフィール画像">
+                        <img class="profile_image" src="./still/profile.png" alt="プロフィール画像">
                     </div>
                     <div class="profile">
                         <p class="profile_name">タイトルタイトル</p>
                         <p class="profile_text">テキストテキストテキスト</p>
-                        <img class="profile_image" src="/still/profile.png" alt="プロフィール画像">
+                        <img class="profile_image" src="./still/profile.png" alt="プロフィール画像">
                     </div>
                     <div class="profile">
                         <p class="profile_name">タイトルタイトル</p>
                         <p class="profile_text">テキストテキストテキスト</p>
-                        <img class="profile_image" src="/still/profile.png" alt="プロフィール画像">
+                        <img class="profile_image" src="./still/profile.png" alt="プロフィール画像">
                     </div>
                 </div>
             </div>
-            <p class="footer">© 2023 taro suzuki</p>
         </div>
     </div>
+    <p class="footer">© 2023 taro suzuki</p>
 </body>
 
 </html>

--- a/html_css_output_beginner/style.css
+++ b/html_css_output_beginner/style.css
@@ -7,7 +7,6 @@ html {
 .container {
     display: block;
     padding: 0 4%;
-    /* width: 600px; */
     text-align: center;
     margin:  0 auto;
 }
@@ -19,15 +18,15 @@ html {
 .header ul {
     display: flex;
     list-style: none;
-    width: 400px;
     justify-content: space-between;
     gap: 40px;
-    margin-right: auto;
     margin-left: auto;
     font-weight: lighter;
 }
 
-span {
+h1 {
+    width: 100px;
+    font-size: 20px;
     font-weight: bold;
     color: white;
     background-color: rgb(56, 55, 55);
@@ -107,8 +106,8 @@ span {
     margin:  0 auto;
 }
 
-.header ul {
-    width: 100%;
+.header ul li {
+    text-align: right;
 }
 
 ul li:nth-of-type(2) {
@@ -126,7 +125,7 @@ span {
 }
 
 .self_text {
-    width: 57%;
+    /* width: 57%; */
 }
 
 .self_art {
@@ -159,8 +158,7 @@ span {
 
 .footer {
     width: 100vw;
-    margin-left: 0;
-    margin-left: calc(50% - 50vw);
+    
 }
 
 }

--- a/html_css_output_beginner/style.css
+++ b/html_css_output_beginner/style.css
@@ -65,7 +65,6 @@ h1 {
 
 .self_image {
     border-radius: 50%;
-    width: 25%;
     align-items: center;
 }
 
@@ -139,10 +138,6 @@ span {
     width: 100%;
 }
 
-.self_image {
-    width: 13%;
-    /* margin-right: 130px; */
-}
 
 .profile_img_wrapper {
     display: flex;
@@ -154,7 +149,7 @@ span {
 }
 
 .footer {
-    width: 100vw;
+    /* width: 100vw; */
     
 }
 

--- a/html_css_output_beginner/style.css
+++ b/html_css_output_beginner/style.css
@@ -13,24 +13,24 @@ html {
 
 .header {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .header ul {
     display: flex;
     list-style: none;
-    justify-content: space-between;
     gap: 40px;
-    margin-left: auto;
     font-weight: lighter;
+    align-items: center;
 }
 
 h1 {
-    width: 100px;
     font-size: 20px;
     font-weight: bold;
     color: white;
     background-color: rgb(56, 55, 55);
-    padding: 10px 20px;
+    padding: 20px 20px;
 }
 
 .main_image {
@@ -66,7 +66,7 @@ h1 {
 .self_image {
     border-radius: 50%;
     width: 25%;
-    margin-top: 20px;
+    align-items: center;
 }
 
 .profile_wrapper {
@@ -106,9 +106,6 @@ h1 {
     margin:  0 auto;
 }
 
-.header ul li {
-    text-align: right;
-}
 
 ul li:nth-of-type(2) {
     margin-left: auto;
@@ -121,7 +118,8 @@ span {
 .self {
     display: flex;
     align-items: flex-start;
-    padding-left: 130px;
+    justify-content: center;
+    gap: 30px;
 }
 
 .self_text {
@@ -129,12 +127,11 @@ span {
 }
 
 .self_art {
-    flex: 1;
+    /* flex: 1; */
 }
 
 .self_name {
     font-size: 18px;
-    font-weight: bold;
     text-align: left;
 }
 
@@ -144,7 +141,7 @@ span {
 
 .self_image {
     width: 13%;
-    margin-right: 130px;
+    /* margin-right: 130px; */
 }
 
 .profile_img_wrapper {


### PR DESCRIPTION
## 課題のリンク

https://github.com/Kenichi585-sys/hc_practice/tree/main/html_css_output_beginner
GitHub PagesのURL：https://kenichi585-sys.github.io/hc_practice/html_css_output_beginner/

## やったこと
以下の内容を修正

＞レジュメに関しては、ulには含めず、h1タグが良いですね。
＞また、親のheaderタグの中に左側部分のh1タグ、右側のulタグを配置するのが良いですね。
h１タグに切り替えてulタグから出しました

＞コンテンツの幅はなるべくそのまま利用して、
＞display: flexで横並びにしている場合は、gapで要素かんのスペースを開けたり、justify-contentを利用して、配置するようにしましょう。
こちらですがなぜ書いてるか思い出せず、消してもなんの影響もなかったためそのまま削除しました

＞margin-leftは使わないで配置しましょう。
footerをcontainerから出すことで左から配置されるようになったため、margin-leftは削除しました

## 動作確認方法

* GitHub Pagesへのアクセスをお願いします

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
・PRのやり方間違ってるかもしれないです。（新しく作成してしまったようで、りょうさんの方で前回の続きから見れなかったらすみません）いまだにGitHubからどのタイミングでマージをするかわからず、、あと間違ってGitHubからマージ後にローカルのmainで作業してしまったので、作業後に新規のブランチを作成してPRをしています。そのため、beginner2というブランチかPRされていると思います。

・相変わらずiPadminiなどでレイアウトが崩れていますが、こちらは@media screen and (min-width: 600px){
    .container { width: 960px;}の影響だと思われます。
課題の仕様に
＞コンテンツ幅
＞コンテンツの横幅は960pxで横のパディングは4%です。
とあるため、仕様を満たすために記載していますが問題ないでしょうか？